### PR TITLE
Please support clang

### DIFF
--- a/seq/type_traits.hpp
+++ b/seq/type_traits.hpp
@@ -34,7 +34,7 @@
 
 namespace std
 {
-#if defined(__GNUG__) && (__GNUC__ < 5)
+#if !defined(__clang__) && defined(__GNUG__) && (__GNUC__ < 5)
 
 	// Reimplement the wheel for older gcc
 


### PR DESCRIPTION
I met a compilation error on clang 13.

```
In file included from include/seq/devector.hpp:32:
include/seq/type_traits.hpp:43:9: error: redefinition of 'is_trivially_copyable'
        struct is_trivially_copyable
               ^
/usr/local/bin/../lib/gcc/x86_64-linux-gnu/10.3.0/../../../../include/c++/10.3.0/type_traits:676:12: note: previous definition is here
    struct is_trivially_copyable
           ^
In file included from /home/conan/workspace/prod-v1/bsr/cci-3b6fc35d/recipes/seq/all/test_package/test_package.cpp:2:
In file included from include/seq/devector.hpp:32:
include/seq/type_traits.hpp:49:9: error: redefinition of 'is_trivially_move_assignable'
        struct is_trivially_move_assignable : is_trivially_copyable<T> {};
               ^
/usr/local/bin/../lib/gcc/x86_64-linux-gnu/10.3.0/../../../../include/c++/10.3.0/type_traits:1318:12: note: previous definition is here
    struct is_trivially_move_assignable
           ^
```

This is caused by the `is_trivially_copyable` condition.
The `__GNUG__` and `__GNUC__` macros are defined in clang as well as gcc.
The presence of the `__clang__` macro should be checked to distinguish it from gcc.

